### PR TITLE
Arduinoのスペル変更

### DIFF
--- a/Ws2822s.cpp
+++ b/Ws2822s.cpp
@@ -8,7 +8,6 @@
 // アドレス設定  setAddress(LEDの先頭番号、LEDの末尾番号)
 //******************************************************************
 
-#include "arduino.h"
 #include "Ws2822s.h"
 
 Ws2822s::Ws2822s(uint8_t dai,int pixel_num)

--- a/Ws2822s.h
+++ b/Ws2822s.h
@@ -10,7 +10,7 @@
 
 #ifndef Ws2822s_h
 #define Ws2822s_h
-#include "arduino.h"
+#include "Arduino.h"
 
 class Ws2822s
 {


### PR DESCRIPTION
便利なライブラリを共有して頂きありがとうございます。

自分の環境で動作させようとしたところ、下記のエラーが出ました。

```
Arduino: 1.8.1 (Linux), Board: "Arduino/Genuino Uno"

In file included from /tmp/arduino_modified_sketch_296137/LED_bar_10.ino:10:0:
/home/asuki/Arduino/libraries/WS2822S-master/Ws2822s.h:13:21: fatal error: arduino.h: No such file or directory
 #include "arduino.h"
                     ^
compilation terminated.
```

自分の環境

種別 | 名前 | バージョン
---- | ---- | ----
OS | ubuntu | 16.10
ビルドツール | ArduinoIDE | 1.8.1
Arduino | UNO | R3

`arduino` を `Arduino` に変更したら、期待通りに動かすことができました。

また、ヘッダファイルで `Arduino.h` を呼び出していれば、 `cpp` ファイルで呼び出さなくても良いため、 `cpp` の `Arduino.h` の記述は削除しました。

よろしければマージをお願いします。